### PR TITLE
fix(overlay): product selection failed due to old reference

### DIFF
--- a/src/views/uikit/OverlayDoc.vue
+++ b/src/views/uikit/OverlayDoc.vue
@@ -13,7 +13,6 @@ const visibleBottom = ref(false);
 const visibleFull = ref(false);
 const products = ref(null);
 const selectedProduct = ref(null);
-const op = ref(null);
 const op2 = ref(null);
 const popup = ref(null);
 
@@ -45,7 +44,7 @@ function toggleDataTable(event) {
 }
 
 function onProductSelect(event) {
-    op.value.hide();
+    op2.value.hide();
     toast.add({ severity: 'info', summary: 'Product Selected', detail: event.data.name, life: 3000 });
 }
 


### PR DESCRIPTION
## Description
Selecting a product did not close the popup due to `op.value is null` exception.

## Assumed cause
`op` reference was used at some point for a different popup overlay. I'm assuming the variable was mixed up during removal.

## Solution
Remove old reference