### PR TITLE
Update vite.config.mjs to fix Deprecation Warning : The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -20,5 +20,12 @@ export default defineConfig({
         alias: {
             '@': fileURLToPath(new URL('./src', import.meta.url))
         }
+    },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                api : "modern",
+            }
+        }
     }
 });


### PR DESCRIPTION
To fix the Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

After running the project, there will be a warning in the console as below screenshot:
![屏幕截图 2025-03-18 142422](https://github.com/user-attachments/assets/24c7a8af-7bf3-4153-8abf-85f3cb1ce7da)

According to the Vite documentation add the css config in  vite.config.mjs file.
https://vite.dev/config/shared-options.html#css-preprocessoroptions
<img width="344" alt="image" src="https://github.com/user-attachments/assets/859a1b2d-8b02-40b0-8591-7e294cab89ce" />
